### PR TITLE
add classpath scanning

### DIFF
--- a/ganjex-core/pom.xml
+++ b/ganjex-core/pom.xml
@@ -1,164 +1,164 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright (c) 2018 Behsa Corporation.
-  ~
-  ~   This file is part of Ganjex.
-  ~
-  ~    Ganjex is free software: you can redistribute it and/or modify
-  ~    it under the terms of the GNU Lesser General Public License as published by
-  ~    the Free Software Foundation, either version 3 of the License, or
-  ~    (at your option) any later version.
-  ~
-  ~    Ganjex is distributed in the hope that it will be useful,
-  ~    but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  ~    GNU Lesser General Public License for more details.
-  ~
-  ~    You should have received a copy of the GNU Lesser General Public License
-  ~    along with Ganjex.  If not, see <http://www.gnu.org/licenses/>.
-  -->
+<!-- ~ Copyright (c) 2018 Behsa Corporation. ~ ~ This file is part of Ganjex. 
+	~ ~ Ganjex is free software: you can redistribute it and/or modify ~ it under 
+	the terms of the GNU Lesser General Public License as published by ~ the 
+	Free Software Foundation, either version 3 of the License, or ~ (at your 
+	option) any later version. ~ ~ Ganjex is distributed in the hope that it 
+	will be useful, ~ but WITHOUT ANY WARRANTY; without even the implied warranty 
+	of ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the ~ GNU Lesser 
+	General Public License for more details. ~ ~ You should have received a copy 
+	of the GNU Lesser General Public License ~ along with Ganjex. If not, see 
+	<http://www.gnu.org/licenses/>. -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>com.behsacorp</groupId>
-        <artifactId>ganjex-parent</artifactId>
-        <version>0.3-RELEASE</version>
-        <relativePath>../</relativePath>
-    </parent>
-    <artifactId>ganjex</artifactId>
-    <packaging>jar</packaging>
-    <name>Ganjex</name>
-    <description>Ganjex container core library</description>
-    <organization>
-        <name>Behsa Co.</name>
-        <url>http://www.behsacorp.com</url>
-    </organization>
-    <licenses>
-        <license>
-            <name>GNU Lesser General Public License</name>
-            <url>http://www.gnu.org/licenses/lgpl-3.0.html</url>
-        </license>
-    </licenses>
-    <developers>
-        <developer>
-            <id>hekmatof</id>
-            <name>Esa Hekmatizadeh</name>
-            <email>i.hekmatizadeh at behsacorp.com</email>
-            <organization>Behsa Co.</organization>
-            <organizationUrl>http://www.behsacorp.com</organizationUrl>
-            <roles>
-                <role>Project lead</role>
-            </roles>
-        </developer>
-    </developers>
-    <scm>
-        <connection>scm:git:git://github.com/behsa-oss/ganjex.git</connection>
-        <developerConnection>scm:git:ssh://github.com:behsa-oss/ganjex.git</developerConnection>
-        <url>http://github.com/behsa-oss/ganjex/tree/master</url>
-    </scm>
-    <distributionManagement>
-        <snapshotRepository>
-            <id>central-snapshot</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>central-release</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
-    </distributionManagement>
-    <dependencies>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
-        <!--testing-->
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-exec</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.20.1</version>
-            </plugin>
-        </plugins>
-    </build>
-    <profiles>
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar-no-fork</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.9.1</version>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.behsacorp</groupId>
+		<artifactId>ganjex-parent</artifactId>
+		<version>0.3-RELEASE</version>
+		<relativePath>../</relativePath>
+	</parent>
+	<artifactId>ganjex</artifactId>
+	<packaging>jar</packaging>
+	<name>Ganjex</name>
+	<description>Ganjex container core library</description>
+	<organization>
+		<name>Behsa Co.</name>
+		<url>http://www.behsacorp.com</url>
+	</organization>
+	<licenses>
+		<license>
+			<name>GNU Lesser General Public License</name>
+			<url>http://www.gnu.org/licenses/lgpl-3.0.html</url>
+		</license>
+	</licenses>
+	<developers>
+		<developer>
+			<id>hekmatof</id>
+			<name>Esa Hekmatizadeh</name>
+			<email>i.hekmatizadeh at behsacorp.com</email>
+			<organization>Behsa Co.</organization>
+			<organizationUrl>http://www.behsacorp.com</organizationUrl>
+			<roles>
+				<role>Project lead</role>
+			</roles>
+		</developer>
+	</developers>
+	<scm>
+		<connection>scm:git:git://github.com/behsa-oss/ganjex.git</connection>
+		<developerConnection>scm:git:ssh://github.com:behsa-oss/ganjex.git</developerConnection>
+		<url>http://github.com/behsa-oss/ganjex/tree/master</url>
+	</scm>
+	<distributionManagement>
+		<snapshotRepository>
+			<id>central-snapshot</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+		</snapshotRepository>
+		<repository>
+			<id>central-release</id>
+			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+		</repository>
+	</distributionManagement>
+	<dependencies>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+		</dependency>
+		<!--testing -->
+		<dependency>
+			<groupId>org.testng</groupId>
+			<artifactId>testng</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-exec</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.shrinkwrap</groupId>
+			<artifactId>shrinkwrap-api</artifactId>
+			<version>1.2.6</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.shrinkwrap</groupId>
+			<artifactId>shrinkwrap-impl-base</artifactId>
+			<version>1.2.6</version>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>2.20.1</version>
+			</plugin>
+		</plugins>
+	</build>
+	<profiles>
+		<profile>
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-source-plugin</artifactId>
+						<version>2.2.1</version>
+						<executions>
+							<execution>
+								<id>attach-sources</id>
+								<goals>
+									<goal>jar-no-fork</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<version>2.9.1</version>
+						<executions>
+							<execution>
+								<id>attach-javadocs</id>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>1.5</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/ganjex-core/src/main/java/com/behsacorp/ganjex/api/GanjexConfiguration.java
+++ b/ganjex-core/src/main/java/com/behsacorp/ganjex/api/GanjexConfiguration.java
@@ -19,6 +19,12 @@
 
 package com.behsacorp.ganjex.api;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 /**
  * This is an immutable class stores the configurations required by Ganjex container. An instance
  * of this class should be passed to <code>{@link Ganjex}.run(GanjexConfiguration) </code> static
@@ -33,13 +39,27 @@ public final class GanjexConfiguration {
 	private final String servicePath;
 	private final long watcherDelay;//in second
 	private final Object[] hooks;
+	private final Set<String> classPaths;
 
 	private GanjexConfiguration(Builder builder) {
 		this.libPath = builder.libPath;
 		this.servicePath = builder.servicePath;
 		this.watcherDelay = builder.watcherDelay;
 		this.hooks = builder.hooks;
+		this.classPaths = builder.classPaths;
 	}
+	
+	
+
+	/**
+	 * 
+	 * @return path to create jar file automatically 
+	 */
+	public Set<String> getClassPaths() {
+		return classPaths;
+	}
+
+
 
 	/**
 	 * @return path of the directory where libraries jar files resort there
@@ -77,6 +97,10 @@ public final class GanjexConfiguration {
 		private String servicePath;
 		private long watcherDelay;//in second
 		private Object[] hooks;
+		/**
+		 * comma separated classpath project scanning 
+		 */
+		private Set<String> classPaths;
 
 		/**
 		 * @param libPath path of the directory where libraries jar files resort there
@@ -84,6 +108,16 @@ public final class GanjexConfiguration {
 		 */
 		public Builder libPath(String libPath) {
 			this.libPath = libPath;
+			return this;
+		}
+		
+		public Builder classPaths(String[] path) {
+			if(classPaths == null)
+				classPaths = new HashSet<>();
+			if(path != null)
+			{				
+				classPaths.addAll(Arrays.asList(path));
+			}
 			return this;
 		}
 

--- a/ganjex-core/src/main/java/com/behsacorp/ganjex/watch/ClassPathFileChangeListener.java
+++ b/ganjex-core/src/main/java/com/behsacorp/ganjex/watch/ClassPathFileChangeListener.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2018 Behsa Corporation.
+ *
+ *   This file is part of Ganjex.
+ *
+ *    Ganjex is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU Lesser General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    Ganjex is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Lesser General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Lesser General Public License
+ *    along with Ganjex.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.behsacorp.ganjex.watch;
+
+import java.io.File;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.importer.ExplodedImporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.behsacorp.ganjex.container.GanjexApplication;
+import com.behsacorp.ganjex.lifecycle.ServiceDestroyer;
+import com.behsacorp.ganjex.lifecycle.ServiceStarter;
+
+/**
+ * The <b>ClassPathFileChangeListener</b> class by implementing
+ * {@link FileChangeListener} is a listener of changes in the services
+ * directory. This listener create {@link ServiceStarter} and
+ * {@link ServiceDestroyer} instance for each service added(or modified) or
+ * removed from the directory and call the deploy or destroy method of that
+ * objects
+ * <p>
+ * An instance of this class should be assign to {@link JarWatcher} constructor
+ * as a listener.
+ *
+ * @author omidp
+ * @see ServiceStarter
+ * @see ServiceDestroyer
+ * @see FileChangeListener
+ * @since 1.0
+ */
+public class ClassPathFileChangeListener implements FileChangeListener {
+	private static final Logger log = LoggerFactory.getLogger(ClassPathFileChangeListener.class);
+	private final GanjexApplication app;
+
+	public ClassPathFileChangeListener(GanjexApplication app) {
+		this.app = app;		
+	}
+
+	private void createArchive() {
+		int cnt = 0;
+		for (String cp : app.config().getClassPaths()) {
+			log.info("creating service jar file for path {}", cp);
+			String name = cnt + ".jar";
+			JavaArchive archive = ShrinkWrap.create(JavaArchive.class, name);
+			JavaArchive explodedArchive = ShrinkWrap.create(ExplodedImporter.class, name).importDirectory(new File(cp))
+					.as(JavaArchive.class);
+			archive.merge(explodedArchive);
+			archive.as(ZipExporter.class)
+					.exportTo(new File(app.config().getServicePath() + File.separator + name), true);
+			cnt++;
+		}
+
+	}
+
+	@Override
+	public void fileAdd(File file) {
+		log.info("new file added to jar {}", file.getName());
+		createArchive();
+	}
+
+	@Override
+	public void fileRemoved(File file) {
+		log.info("service {} is removed", file.getName());
+		createArchive();
+	}
+
+}

--- a/ganjex-core/src/main/java/com/behsacorp/ganjex/watch/Watcher.java
+++ b/ganjex-core/src/main/java/com/behsacorp/ganjex/watch/Watcher.java
@@ -1,0 +1,12 @@
+package com.behsacorp.ganjex.watch;
+
+/**
+ * @author omidp
+ *
+ */
+public interface Watcher {
+
+	
+	public void check();
+	public void destroy();
+}

--- a/ganjex-core/src/test/java/com/behsacorp/ganjex/integration/dynamicLibrary/ClassPathScanningTest.java
+++ b/ganjex-core/src/test/java/com/behsacorp/ganjex/integration/dynamicLibrary/ClassPathScanningTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2018 Behsa Corporation.
+ *
+ *   This file is part of Ganjex.
+ *
+ *    Ganjex is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU Lesser General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    Ganjex is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Lesser General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Lesser General Public License
+ *    along with Ganjex.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.behsacorp.ganjex.integration.dynamicLibrary;
+
+import com.behsacorp.ganjex.api.Ganjex;
+import com.behsacorp.ganjex.api.GanjexConfiguration;
+import com.behsacorp.ganjex.integration.TestUtil;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+import static com.behsacorp.ganjex.integration.TestUtil.*;
+
+/**
+ * @author omidp
+ */
+@Test(sequential = true)
+public class ClassPathScanningTest {
+	private Ganjex ganjex;
+
+	@Test
+	public void testDynamicLibrary() throws IOException, InterruptedException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+		clean();
+		ganjex = Ganjex.run(new GanjexConfiguration.Builder()
+						.libPath(TestUtil.libPath)
+						.servicePath(TestUtil.servicePath)
+						.watcherDelay(1)
+						.classPaths(new String[]{"../../../sample/sampleWebFramework/web-sample-service-hello/target/classes", "noop"})
+						.hooks(new FrameworkHook())
+						.build());
+		deployLib(TEST_PATH + "dynamicLibrary/dynamicLib/", "dynamic-lib");
+		Thread.sleep(TIMEOUT);
+		deployService(TEST_PATH + "dynamicLibrary/someService/", "service1");
+		Thread.sleep(TIMEOUT);
+		Assert.assertEquals(FrameworkHook.invokeMethodOnService(), "hello world");
+		Thread.sleep(TIMEOUT);
+		deployLib(TEST_PATH + "dynamicLibrary/dynamicLib2/", "dynamic-lib");
+		Thread.sleep(TIMEOUT);
+		Assert.assertEquals(FrameworkHook.invokeMethodOnService(), "hello world2");
+	}
+
+	@AfterClass
+	public void destroy() throws InterruptedException {
+		ganjex.destroy();
+	}
+
+}

--- a/ganjex-spring-boot/ganjex-spring-boot-autoconfigure/src/main/java/com/behsacorp/ganjex/config/GanjexAutoConfiguration.java
+++ b/ganjex-spring-boot/ganjex-spring-boot-autoconfigure/src/main/java/com/behsacorp/ganjex/config/GanjexAutoConfiguration.java
@@ -52,6 +52,7 @@ public class GanjexAutoConfiguration {
 						.servicePath(ganjexProperties.getServicePath())
 						.libPath(ganjexProperties.getLibPath())
 						.watcherDelay(ganjexProperties.getWatchDelay())
+						.classPaths(ganjexProperties.getClassPaths().split(","))
 						.hooks(hookMap.values().toArray()).build()
 		);
 		log.info("ganjex container bootstrap finished");

--- a/ganjex-spring-boot/ganjex-spring-boot-autoconfigure/src/main/java/com/behsacorp/ganjex/config/GanjexProperties.java
+++ b/ganjex-spring-boot/ganjex-spring-boot-autoconfigure/src/main/java/com/behsacorp/ganjex/config/GanjexProperties.java
@@ -30,6 +30,15 @@ public class GanjexProperties {
 	private String servicePath = "service";
 	private String libPath = "lib";
 	private int watchDelay = 10;
+	private String classPaths = "classes";
+	
+	public String getClassPaths() {
+		return classPaths;
+	}
+
+	public void setClassPaths(String classPaths) {
+		this.classPaths = classPaths;
+	}
 
 	public String getServicePath() {
 		return servicePath;

--- a/sample/sampleWebFramework/web-sample-framework/src/main/resources/application.properties
+++ b/sample/sampleWebFramework/web-sample-framework/src/main/resources/application.properties
@@ -19,3 +19,4 @@
 ganjex.lib-path=../../../dist/libs
 ganjex.service-path=../../../dist/services
 ganjex.watch-delay=4
+ganjex.class-paths=../../../sample/sampleWebFramework/web-sample-service-hello/target/classes


### PR DESCRIPTION
it is difficult to maintain your microservices with ganjex especially when you are developing on top of ganjex, the process is cumbersome you need to build your project wait until build is finished then copy & paste the jar file manually to ganjex service directory. 
ClasspathScanning allows you to automatically deploy your project into ganjex service directory.
It creates a jar file and deploy it without involving you.
It also support multiple classpathscanning.